### PR TITLE
`ClosedAuditID` part deux

### DIFF
--- a/redundant-history/remove-redundant-BaseAssert-reopen-and-close-history.sql
+++ b/redundant-history/remove-redundant-BaseAssert-reopen-and-close-history.sql
@@ -92,7 +92,7 @@ print @rowcount + ' BaseAsset history records restitched'
 alter table dbo.BaseAsset_Now disable trigger all
 
 -- sync up BaseAsset_Now with history tips from BaseAsset
-update dbo.BaseAsset_Now set AuditBegin=BaseAsset.AuditBegin 
+update dbo.BaseAsset_Now set AuditBegin=BaseAsset.AuditBegin, ClosedAuditID=BaseAsset.ClosedAuditID
 from dbo.BaseAsset
 where BaseAsset.ID=BaseAsset_Now.ID and BaseAsset.AuditEnd is null and BaseAsset.AuditBegin<>BaseAsset_Now.AuditBegin
 


### PR DESCRIPTION
re-sync `BaseAsset_Now.ClosedAuditID` from `BaseAsset`, since we whacked the most-recent closure, thus making this asset effectively appear to be closed earlier