### PR TITLE
`Asset` history is never redundant

### DIFF
--- a/redundant-history/remove-redundant-asset-history.sql
+++ b/redundant-history/remove-redundant-asset-history.sql
@@ -101,7 +101,7 @@ from (
 			'AssetType', 'AttributeDefinition', 'BaseRule', 'BaseSyntheticAttributeDefinition', 'DefaultRule', 'EventDefinition', 'ExecuteSecurityCheckAttributeDefinition', 'InsertUpdateRule', 'ManyToManyRelationDefinition', 'Operation', 'Override', 'RelationDefinition', 
 			
 			-- Skip "system" assets
-			'Role', 'State'
+			'Asset', 'Role', 'State'
 		)
 )_
 


### PR DESCRIPTION
... even though it looks that way to this script